### PR TITLE
Exclude dtolnay/rust-toolchain from dependabot

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -7,6 +7,11 @@ updates:
       interval: daily
     commit-message:
       prefix: "chore(deps)"
+    ignore:
+      # See https://github.com/dtolnay/rust-toolchain/issues/45 tags aren't used
+      # by rust-toolchain. Using a branch name will cause dependabot to suggest
+      # which ever branch happens to be the newest
+      - dependency-name: "rust-toolchain"
   - package-ecosystem: github-actions
     directory: '/'
     schedule:

--- a/rust/repo/tests/basic-agpl3/output/repository/.github/dependabot.yaml
+++ b/rust/repo/tests/basic-agpl3/output/repository/.github/dependabot.yaml
@@ -18,3 +18,8 @@ updates:
       prefix: "chore(deps)"
     reviewers:
       - "mobilecoinfoundation/coredev"
+    ignore:
+      # See https://github.com/dtolnay/rust-toolchain/issues/45 tags aren't used
+      # by rust-toolchain. Using a branch name will cause dependabot to suggest
+      # which ever branch happens to be the newest
+      - dependency-name: "rust-toolchain"

--- a/rust/repo/tests/basic-gpl3/output/repository/.github/dependabot.yaml
+++ b/rust/repo/tests/basic-gpl3/output/repository/.github/dependabot.yaml
@@ -18,3 +18,8 @@ updates:
       prefix: "chore(deps)"
     reviewers:
       - "mobilecoinfoundation/coredev"
+    ignore:
+      # See https://github.com/dtolnay/rust-toolchain/issues/45 tags aren't used
+      # by rust-toolchain. Using a branch name will cause dependabot to suggest
+      # which ever branch happens to be the newest
+      - dependency-name: "rust-toolchain"

--- a/rust/repo/tests/basic-x86_64/output/repository/.github/dependabot.yaml
+++ b/rust/repo/tests/basic-x86_64/output/repository/.github/dependabot.yaml
@@ -18,3 +18,8 @@ updates:
       prefix: "chore(deps)"
     reviewers:
       - "mobilecoinfoundation/coredev"
+    ignore:
+      # See https://github.com/dtolnay/rust-toolchain/issues/45 tags aren't used
+      # by rust-toolchain. Using a branch name will cause dependabot to suggest
+      # which ever branch happens to be the newest
+      - dependency-name: "rust-toolchain"

--- a/rust/repo/tests/basic/output/repository/.github/dependabot.yaml
+++ b/rust/repo/tests/basic/output/repository/.github/dependabot.yaml
@@ -18,3 +18,8 @@ updates:
       prefix: "chore(deps)"
     reviewers:
       - "mobilecoinfoundation/coredev"
+    ignore:
+      # See https://github.com/dtolnay/rust-toolchain/issues/45 tags aren't used
+      # by rust-toolchain. Using a branch name will cause dependabot to suggest
+      # which ever branch happens to be the newest
+      - dependency-name: "rust-toolchain"

--- a/rust/repo/tests/crate/output/repository/.github/dependabot.yaml
+++ b/rust/repo/tests/crate/output/repository/.github/dependabot.yaml
@@ -18,3 +18,8 @@ updates:
       prefix: "chore(deps)"
     reviewers:
       - "mobilecoinfoundation/coredev"
+    ignore:
+      # See https://github.com/dtolnay/rust-toolchain/issues/45 tags aren't used
+      # by rust-toolchain. Using a branch name will cause dependabot to suggest
+      # which ever branch happens to be the newest
+      - dependency-name: "rust-toolchain"

--- a/rust/repo/{{ cookiecutter.repo_name }}/.github/dependabot.yaml
+++ b/rust/repo/{{ cookiecutter.repo_name }}/.github/dependabot.yaml
@@ -18,3 +18,8 @@ updates:
       prefix: "chore(deps)"
     reviewers:
       - "mobilecoinfoundation/coredev"
+    ignore:
+      # See https://github.com/dtolnay/rust-toolchain/issues/45 tags aren't used
+      # by rust-toolchain. Using a branch name will cause dependabot to suggest
+      # which ever branch happens to be the newest
+      - dependency-name: "rust-toolchain"


### PR DESCRIPTION
dtolnay/rust-toolchain uses branches to track and customize the github
action version and behavior.
This causes issues with dependabot which prefers release tags.
Dependabot will suggest using the newest branch. For example
dtolnay/rust-toolchain suggest using `@stable` to use the stable rust
version and to use `@master` with arguments to specify specific rust
versions. If the `stable` branch is newer than `master` dependabot will
make a pr to use `stable`, but this will break the intended behavior of
not using a `stable` rust version

