### PR TITLE
be consistent about what rust toolchain we use

### DIFF
--- a/rust/repo/{{ cookiecutter.repo_name }}/.github/workflows/ci.yaml
+++ b/rust/repo/{{ cookiecutter.repo_name }}/.github/workflows/ci.yaml
@@ -153,7 +153,7 @@ jobs:
       fail-fast: false
     steps:
       - uses: actions/checkout@v3
-      - uses: dtolnay/rust-toolchain@master
+      - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: ${{ matrix.rust }}
           components: clippy
@@ -174,7 +174,7 @@ jobs:
           - nightly-2023-01-04
     steps:
       - uses: actions/checkout@v3
-      - uses: dtolnay/rust-toolchain@master
+      - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: ${{ matrix.rust }}
       - uses: r7kamura/rust-problem-matchers@v1
@@ -192,7 +192,7 @@ jobs:
           - nightly-2023-01-04
     steps:
       - uses: actions/checkout@v3
-      - uses: dtolnay/rust-toolchain@master
+      - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: ${{ matrix.rust }}
       - uses: r7kamura/rust-problem-matchers@v1
@@ -211,7 +211,7 @@ jobs:
     continue-on-error: ${{ matrix.rust == 'beta' }}
     steps:
       - uses: actions/checkout@v3
-      - uses: dtolnay/rust-toolchain@master
+      - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: ${{ matrix.rust }}
       - uses: r7kamura/rust-problem-matchers@v1


### PR DESCRIPTION
in some parts of this, we use rust-toolchain@master, and in some we use @stable

i don't see why to use @master, i'm finding that i can do things with stable usually @master seems scary, why not @nightly?