### PR TITLE
remove references to `gpl-v3-only` and `gpl-v3-or-later`

### DIFF
--- a/rust/repo/examples/license-agpl3/output/repository/deny.toml
+++ b/rust/repo/examples/license-agpl3/output/repository/deny.toml
@@ -19,12 +19,9 @@ allow = [
     "ISC",
     "MIT",
     "Unicode-DFS-2016",
-    "GPL-3.0-only",
-    "GPL-3.0-or-later",
-    "LGPL-3.0-only",
-    "LGPL-3.0-or-later",
-    "AGPL-3.0-only",
-    "AGPL-3.0-or-later",
+    "GPL-3.0",
+    "LGPL-3.0",
+    "AGPL-3.0",
 ]
 deny = []
 copyleft = "allow"

--- a/rust/repo/examples/license-gpl3/output/repository/deny.toml
+++ b/rust/repo/examples/license-gpl3/output/repository/deny.toml
@@ -19,10 +19,8 @@ allow = [
     "ISC",
     "MIT",
     "Unicode-DFS-2016",
-    "GPL-3.0-only",
-    "GPL-3.0-or-later",
-    "LGPL-3.0-only",
-    "LGPL-3.0-or-later",
+    "GPL-3.0",
+    "LGPL-3.0",
 ]
 deny = []
 copyleft = "allow"

--- a/rust/repo/{{ cookiecutter.repo_name }}/deny.toml
+++ b/rust/repo/{{ cookiecutter.repo_name }}/deny.toml
@@ -20,14 +20,11 @@ allow = [
     "MIT",
     "Unicode-DFS-2016",
 {%- if cookiecutter.license in ("GPL-3.0-only", "AGPL-3.0-only") %}
-    "GPL-3.0-only",
-    "GPL-3.0-or-later",
-    "LGPL-3.0-only",
-    "LGPL-3.0-or-later",
+    "GPL-3.0",
+    "LGPL-3.0",
 {%- endif -%}
 {%- if cookiecutter.license == "AGPL-3.0-only" %}
-    "AGPL-3.0-only",
-    "AGPL-3.0-or-later",
+    "AGPL-3.0",
 {%- endif %}
 ]
 deny = []


### PR DESCRIPTION
cargo deny doesn't seem to recognize these anymore, and it only supports `gpl-v3` for instance, without these qualifiers