### PR TITLE
the cargo sort invocation should have --grouped

### DIFF
--- a/rust/repo/{{ cookiecutter.repo_name }}/.github/workflows/ci.yaml
+++ b/rust/repo/{{ cookiecutter.repo_name }}/.github/workflows/ci.yaml
@@ -138,7 +138,7 @@ jobs:
       - uses: taiki-e/install-action@v2
         with:
           tool: cargo-sort
-      - run: cargo sort --workspace --check >/dev/null
+      - run: cargo sort --workspace --grouped --check >/dev/null
       # TODO: Fix automatically
 
   clippy:


### PR DESCRIPTION
if it doesn't then it doesn't respect our conventions around mobilecoin and thirdparty deps being separated