### PR TITLE
add read permissions (needed for private repos)

### DIFF
--- a/rust/repo/examples/default/output/repository/.github/workflows/ci.yaml
+++ b/rust/repo/examples/default/output/repository/.github/workflows/ci.yaml
@@ -38,6 +38,7 @@ jobs:
     # TODO: once we have enough reviews, make this a required check
     continue-on-error: true
     permissions:
+      contents: read
       pull-requests: write
     steps:
       - uses: actions/checkout@v3

--- a/rust/repo/examples/default/output/repository/.github/workflows/pr-assign.yaml
+++ b/rust/repo/examples/default/output/repository/.github/workflows/pr-assign.yaml
@@ -9,6 +9,7 @@ jobs:
   auto-assign:
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       pull-requests: write
     steps:
       - uses: kentaro-m/auto-assign-action@v1.2.5

--- a/rust/repo/{{ cookiecutter.repo_name }}/.github/workflows/ci.yaml
+++ b/rust/repo/{{ cookiecutter.repo_name }}/.github/workflows/ci.yaml
@@ -39,6 +39,7 @@ jobs:
     continue-on-error: true
     permissions:
       pull-requests: write
+      contents: read
     steps:
       - uses: actions/checkout@v3
         with:

--- a/rust/repo/{{ cookiecutter.repo_name }}/.github/workflows/ci.yaml
+++ b/rust/repo/{{ cookiecutter.repo_name }}/.github/workflows/ci.yaml
@@ -38,8 +38,8 @@ jobs:
     # TODO: once we have enough reviews, make this a required check
     continue-on-error: true
     permissions:
-      pull-requests: write
       contents: read
+      pull-requests: write
     steps:
       - uses: actions/checkout@v3
         with:

--- a/rust/repo/{{ cookiecutter.repo_name }}/.github/workflows/pr-assign.yaml
+++ b/rust/repo/{{ cookiecutter.repo_name }}/.github/workflows/pr-assign.yaml
@@ -9,6 +9,7 @@ jobs:
   auto-assign:
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       pull-requests: write
     steps:
       - uses: kentaro-m/auto-assign-action@v1.2.5


### PR DESCRIPTION
- Add `read` permission to the `GITHUB_TOKEN` used in actions that require cloning the repo

### Motivation

Without this these actions fail on private repos.