### PR TITLE
Pin crev back to 0.23

### DIFF
--- a/rust/repo/examples/default/output/repository/.github/workflows/ci.yaml
+++ b/rust/repo/examples/default/output/repository/.github/workflows/ci.yaml
@@ -58,7 +58,9 @@ jobs:
           restore-keys: ${{ runner.os }}-cargo-
       - uses: taiki-e/install-action@v2
         with:
-          tool: cargo-crev
+          # Pinning to 0.23 due to
+          # https://github.com/crev-dev/cargo-crev/issues/598
+          tool: cargo-crev@0.23
       - name: Configure Crev
         run: |
           cargo crev trust \

--- a/rust/repo/{{ cookiecutter.repo_name }}/.github/workflows/ci.yaml
+++ b/rust/repo/{{ cookiecutter.repo_name }}/.github/workflows/ci.yaml
@@ -58,7 +58,9 @@ jobs:
           restore-keys: ${{ runner.os }}-cargo-
       - uses: taiki-e/install-action@v2
         with:
-          tool: cargo-crev
+          # Pinning to 0.23 due to
+          # https://github.com/crev-dev/cargo-crev/issues/598
+          tool: cargo-crev@0.23
       - name: Configure Crev
         run: |
           cargo crev trust \


### PR DESCRIPTION
crev version 0.24 will fail to run on a fresh install. In order for the
github actions to work correctly the crev version has been pinned back
to 0.23 until https://github.com/crev-dev/cargo-crev/issues/598 gets
resolved.

