### PR TITLE
Update nightly default to 2023-01-22

### DIFF
--- a/rust/repo/examples/default/output/repository/.github/settings.yml
+++ b/rust/repo/examples/default/output/repository/.github/settings.yml
@@ -98,12 +98,12 @@ branches:
         #         rust:
         #           - stable
         #           - beta
-        #           - nightly-2023-01-04
+        #           - nightly-2023-01-22
         #
         # Then the matrix names would be:
         #   - "build (stable)"
         #   - "build (beta)"
-        #   - "build (nightly-2023-01-04)"
+        #   - "build (nightly-2023-01-22)"
         contexts:
           - lint
           - "deny (bans licenses sources)"

--- a/rust/repo/examples/default/output/repository/.github/workflows/ci.yaml
+++ b/rust/repo/examples/default/output/repository/.github/workflows/ci.yaml
@@ -184,7 +184,7 @@ jobs:
         rust:
           - stable
           - beta
-          - nightly-2023-01-04
+          - nightly-2023-01-22
     steps:
       - uses: actions/checkout@v3
         with:
@@ -204,7 +204,7 @@ jobs:
         rust:
           - stable
           - beta
-          - nightly-2023-01-04
+          - nightly-2023-01-22
     steps:
       - uses: actions/checkout@v3
         with:

--- a/rust/repo/examples/different-org/output/repository/.github/settings.yml
+++ b/rust/repo/examples/different-org/output/repository/.github/settings.yml
@@ -96,12 +96,12 @@ branches:
         #         rust:
         #           - stable
         #           - beta
-        #           - nightly-2023-01-04
+        #           - nightly-2023-01-22
         #
         # Then the matrix names would be:
         #   - "build (stable)"
         #   - "build (beta)"
-        #   - "build (nightly-2023-01-04)"
+        #   - "build (nightly-2023-01-22)"
         contexts:
           - lint
           - "deny (bans licenses sources)"

--- a/rust/repo/{{ cookiecutter.repo_name }}/.github/settings.yml
+++ b/rust/repo/{{ cookiecutter.repo_name }}/.github/settings.yml
@@ -98,12 +98,12 @@ branches:
         #         rust:
         #           - stable
         #           - beta
-        #           - nightly-2023-01-04
+        #           - nightly-2023-01-22
         #
         # Then the matrix names would be:
         #   - "build (stable)"
         #   - "build (beta)"
-        #   - "build (nightly-2023-01-04)"
+        #   - "build (nightly-2023-01-22)"
         contexts:
           - lint
           - "deny (bans licenses sources)"

--- a/rust/repo/{{ cookiecutter.repo_name }}/.github/workflows/ci.yaml
+++ b/rust/repo/{{ cookiecutter.repo_name }}/.github/workflows/ci.yaml
@@ -184,7 +184,7 @@ jobs:
         rust:
           - stable
           - beta
-          - nightly-2023-01-04
+          - nightly-2023-01-22
     steps:
       - uses: actions/checkout@v3
         with:
@@ -204,7 +204,7 @@ jobs:
         rust:
           - stable
           - beta
-          - nightly-2023-01-04
+          - nightly-2023-01-22
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
Previously the nightly used in the CI of the `rust/repo` was 2023-01-04.
This was in the middle of rust 1.68 development and lacked the sparse
checkout support for crates.io. A number of tools keyed off of version 1.68
to determine when to set sparse checkout resulting in failures to
access crates.io. Now nightly 2023-01-22 is used which is the last
nightly for version 1.68 and contains the sparse checkout support.

