### PR TITLE
Reduce code owners to `CODEOWNERS` and `settings.yml`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,13 +1,9 @@
-# These lines impact repository security
+# In order to utilize the [settings app](https://github.com/apps/settings) in a
+# secure manner, we must ensure that both the `CODEOWNERS` and `settings.yml`
+# file have code owners and that `settings.yml` has 
+# `require_code_owner_reviews: true`.
+# We do not mark code owners for other directories as the code owners will be
+# auto-assigned first by github, preventing the use of team auto-assignment.
+# <https://docs.github.com/en/organizations/organizing-members-into-teams/managing-code-review-settings-for-your-team#about-auto-assignment>
 /.github/CODEOWNERS        @nick-mobilecoin @jcape @cbeck88 @samdealy
 /.github/settings.yml      @nick-mobilecoin @jcape @cbeck88 @samdealy
-
-# These lines prevent reviews of trivial changes blocking on particular users
-/.gitignore
-/.markdownlint-cli2.jsonrc
-/LICENSE
-/README.md
-
-# These lines represent original authors and new maintainers
-/.github                   @nick-mobilecoin @jcape @cbeck88 @samdealy
-/rust                      @nick-mobilecoin @jcape @cbeck88 @samdealy

--- a/rust/repo/examples/default/output/repository/.github/CODEOWNERS
+++ b/rust/repo/examples/default/output/repository/.github/CODEOWNERS
@@ -1,17 +1,9 @@
-# These lines impact repository security
+# In order to utilize the [settings app](https://github.com/apps/settings) in a
+# secure manner, we must ensure that both the `CODEOWNERS` and `settings.yml`
+# file have code owners and that `settings.yml` has
+# `require_code_owner_reviews: true`.
+# We do not mark code owners for other directories as the code owners will be
+# auto-assigned first by github, preventing the use of team auto-assignment.
+# <https://docs.github.com/en/organizations/organizing-members-into-teams/managing-code-review-settings-for-your-team#about-auto-assignment>
 /.github/CODEOWNERS        @testuser @jcape
 /.github/settings.yml      @testuser @jcape
-
-# These lines prevent reviews of trivial changes blocking on particular users
-/.gitattributes
-/.gitconfig
-/.gitignore
-/.markdownlint-cli2.jsonrc
-/CHANGELOG.md
-/Cargo.toml
-/Cargo.lock
-/LICENSE
-/README.md
-/deny.toml
-/rust-toolchain.toml
-/rustfmt.toml

--- a/rust/repo/{{ cookiecutter.repo_name }}/.github/CODEOWNERS
+++ b/rust/repo/{{ cookiecutter.repo_name }}/.github/CODEOWNERS
@@ -1,17 +1,9 @@
-# These lines impact repository security
+# In order to utilize the [settings app](https://github.com/apps/settings) in a
+# secure manner, we must ensure that both the `CODEOWNERS` and `settings.yml`
+# file have code owners and that `settings.yml` has
+# `require_code_owner_reviews: true`.
+# We do not mark code owners for other directories as the code owners will be
+# auto-assigned first by github, preventing the use of team auto-assignment.
+# <https://docs.github.com/en/organizations/organizing-members-into-teams/managing-code-review-settings-for-your-team#about-auto-assignment>
 /.github/CODEOWNERS        {{ cookiecutter.owners }}
 /.github/settings.yml      {{ cookiecutter.owners }}
-
-# These lines prevent reviews of trivial changes blocking on particular users
-/.gitattributes
-/.gitconfig
-/.gitignore
-/.markdownlint-cli2.jsonrc
-/CHANGELOG.md
-/Cargo.toml
-/Cargo.lock
-/LICENSE
-/README.md
-/deny.toml
-/rust-toolchain.toml
-/rustfmt.toml


### PR DESCRIPTION
Previously the `CODEOWNERS` file was intended to be used to mark most
code directories with code owners. Require code owners reviews is on for
settings.yml security and at least 3 code owners need to be listed so a
code owner can make a change, get a review from another code owner and
have one code owner OOO. These settings and requirements resulted in the
inability to leverage team auto-assignment,
<https://docs.github.com/en/organizations/organizing-members-into-teams/managing-code-review-settings-for-your-team#about-auto-assignment>.
Now code owners have been limited to only the `CODEOWNERS` and
`settings.yml` files so that team auto assignment works.
