### PR TITLE
Fix issue-labeler action

### DIFF
--- a/.github/workflows/issues.yaml
+++ b/.github/workflows/issues.yaml
@@ -11,7 +11,7 @@ jobs:
   triage:
     runs-on: ubuntu-latest
     steps:
-      - uses: github/issue-labeler@v3
+      - uses: github/issue-labeler@v3.1
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
           configuration-path: .github/triage-labeler.yaml

--- a/rust/repo/examples/default/output/repository/.github/workflows/issues.yaml
+++ b/rust/repo/examples/default/output/repository/.github/workflows/issues.yaml
@@ -11,7 +11,7 @@ jobs:
   triage:
     runs-on: ubuntu-latest
     steps:
-      - uses: github/issue-labeler@v3
+      - uses: github/issue-labeler@v3.1
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
           configuration-path: .github/triage-labeler.yaml

--- a/rust/repo/{{ cookiecutter.repo_name }}/.github/workflows/issues.yaml
+++ b/rust/repo/{{ cookiecutter.repo_name }}/.github/workflows/issues.yaml
@@ -11,7 +11,7 @@ jobs:
   triage:
     runs-on: ubuntu-latest
     steps:
-      - uses: github/issue-labeler@v3
+      - uses: github/issue-labeler@v3.1
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
           configuration-path: .github/triage-labeler.yaml


### PR DESCRIPTION
Previously the issue labeler action was using "@v3". This was resulting
in errors along the lines of:

> Unable to resolve action `github/issue-labeler@v3`, unable to find version `v3`

Now issue-labeler action uses `v3.1` the most up to date release,
<https://github.com/marketplace/actions/regex-issue-labeler?version=v3.1>.

I had misunderstood how github action versioning was handled. I thought
that github actions followed semantic versioning and would see `v3` as
the latest `v3.x.x`. This is *not* how github action versioning works.
Github actions will track a tag name, branch name or sha. Some
maintainers have been providing a major version branch `v3` which all of
the `v3.x.x` tags go into. So for _some_ actions one can follow the `v3`
branch and stay up to date for that major version. Other actions the
maintainers will create a `v3` tag and then add subsequent tags of
`v3.x.x` so one can stay at `v3` or move to `v3.4.7`.

<!-- List changes here -->

### Motivation

<!-- Describe why these changes should happen, e.g. "Currently we...", or "This is needed because..." -->
